### PR TITLE
Drop Python 3.6 support

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: ["3.10"]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/py-ci.yml
+++ b/.github/workflows/py-ci.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9, pypy3]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "pypy-3.8"]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/py-coverage.yml
+++ b/.github/workflows/py-coverage.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.8]
+        python-version: ["3.10"]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/py-lint.yml
+++ b/.github/workflows/py-lint.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.8]
+        python-version: ["3.10"]
 
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ font-line is a libre, open source command line tool for OpenType vertical metric
 
 ## Install
 
-font-line is built with Python and is tested with Python 3.6+ interpreters. You can verify your installed Python version on the command line with the command:
+font-line is built with Python and supports Python 3.7+ interpreters. Check your installed Python version on the command line with the command:
 
 ```
 $ python3 --version
@@ -166,7 +166,7 @@ Unix/Linux/OS X users can write this report to a file with the `>` command line 
 $ font-line report TheFont.ttf > font-report.txt
 ```
 
-You can modify the `font-report.txt` file path above to the file path string of your choice.
+Modify the `font-report.txt` file path above to the file path string of your choice.
 
 #### Baseline to Baseline Distance Calculations
 

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,8 @@ import re
 import sys
 from setuptools import setup, find_packages
 
+REQUIRES_PYTHON = ">=3.7.0"
+
 
 # Use repository Markdown README.md for PyPI long description
 try:
@@ -51,6 +53,7 @@ setup(
     author="Christopher Simpkins",
     author_email="chris@sourcefoundry.org",
     platforms=["any"],
+    python_requires=REQUIRES_PYTHON,
     packages=find_packages("lib"),
     package_dir={"": "lib"},
     install_requires=["commandlines", "standardstreams", "fontTools"],
@@ -66,10 +69,10 @@ setup(
         "Operating System :: OS Independent",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37
+envlist = py310
 
 [testenv]
 commands =


### PR DESCRIPTION
Python 3.6 support was dropped by our fontTools dependency.  We will drop it here so that we can continue to update the dependency going forward.